### PR TITLE
Switch logging of individual paths to verbose; print summary at end.

### DIFF
--- a/tasks/cleanempty.js
+++ b/tasks/cleanempty.js
@@ -51,12 +51,14 @@ module.exports = function(grunt)
 			}
 			
 			
-			grunt.log.write((options["no-write"] ? "Not actually cleaning " : "Cleaning ") + filepath + "...");
+			grunt.verbose.write((options["no-write"] ? "Not actually cleaning " : "Cleaning ") + filepath + "...");
 			
 			grunt.file.delete(filepath, deleteOptions);
 			
-			grunt.log.ok();
+			grunt.verbose.ok();
 		}
+
+		grunt.log.ok(this.filesSrc.length + " " + grunt.util.pluralize(this.filesSrc.length, "path/paths") + " cleaned.")
 	});
 	
 	


### PR DESCRIPTION
This implementation is basically copied from grunt-contrib-clean.
