### PR TITLE
switch continue conditions order

### DIFF
--- a/tasks/cleanempty.js
+++ b/tasks/cleanempty.js
@@ -35,11 +35,11 @@ module.exports = function(grunt)
 			
 			if ( !grunt.file.isDir(filepath) )
 			{
-				if (fs.readFileSync(filepath).length > 0 || !options.files) continue;
+				if (!options.files || fs.readFileSync(filepath).length > 0) continue;
 			}
 			else
 			{
-				if (fs.readdirSync(filepath).length > 0 || !options.folders) continue;
+				if (!options.folders || fs.readdirSync(filepath).length > 0) continue;
 			}
 			
 			


### PR DESCRIPTION
This way, if the task isn't supposed to delete files, it won't read from the file system for no reason 
same for folders